### PR TITLE
run sendmail in foreground

### DIFF
--- a/otrs/etc/supervisord.d/otrs.ini
+++ b/otrs/etc/supervisord.d/otrs.ini
@@ -22,6 +22,8 @@ autorestart=true
 
 [program:sendmail]
 command=/usr/sbin/sendmail -bD
-stdout_logfile=/var/log/supervisor/%(program_name)s.log
-redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
 autorestart=true

--- a/otrs/etc/supervisord.d/otrs.ini
+++ b/otrs/etc/supervisord.d/otrs.ini
@@ -21,7 +21,7 @@ stderr_logfile=/var/log/supervisor/%(program_name)s.log
 autorestart=true
 
 [program:sendmail]
-command=/usr/sbin/sendmail -bd
+command=/usr/sbin/sendmail -bD
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
-stderr_logfile=/var/log/supervisor/%(program_name)s.log
+redirect_stderr=true
 autorestart=true


### PR DESCRIPTION
supervisord expects processes to stay active not daemonize; additional modification: the stderr redirect to stdout instead of concurrent writing to the same file